### PR TITLE
feat: show case numbers with punctuation

### DIFF
--- a/src/components/StatusGeral/index.jsx
+++ b/src/components/StatusGeral/index.jsx
@@ -5,7 +5,7 @@ import "./styles.css";
 const divInfo = (info, p) => {
 	return (
 		<div className="card">
-			<label>{info}</label>
+			<label>{typeof info === 'number' ? (info).toLocaleString('pt-BR') : info}</label>
 			<p>{p}</p>
 		</div>
 	);


### PR DESCRIPTION
Hi @gabrielduete 

I added punctuation in case numbers,
I believe it looks better for viewing.

**Before:**
![screenshot_38](https://user-images.githubusercontent.com/45276342/135773549-337d1562-c42a-4b11-b3a0-166eeb008760.png)
**after:**
![screenshot_39](https://user-images.githubusercontent.com/45276342/135773565-447f818e-a942-42ac-b76a-ef9dde96c18b.png)

I hope it's useful for the project and it would help me with **Hacktoberfest 2021**.